### PR TITLE
Fix rhel9 install and make sure all machine-id's are unique

### DIFF
--- a/packer/rhel7.pkr.hcl
+++ b/packer/rhel7.pkr.hcl
@@ -30,6 +30,6 @@ source "qemu" "rhel7" {
 build {
   sources = ["source.qemu.rhel7"]
   post-processor "shell-local" {
-    inline = ["virt-sysprep -a output-rhel7/packer-rhel-7-x86_64 --operations all,-lvm-uuids,-user-account,-firewall-rules,-fs-uuids,-flag-reconfiguration,-machine-id --scrub /etc/machine-id"]
+    inline = ["virt-sysprep -a output-rhel7/packer-rhel-7-x86_64 --operations defaults,-lvm-uuids --run-command '> /etc/machine-id'"]
   }
 }

--- a/packer/rhel8.pkr.hcl
+++ b/packer/rhel8.pkr.hcl
@@ -30,6 +30,6 @@ source "qemu" "rhel8" {
 build {
   sources = ["source.qemu.rhel8"]
   post-processor "shell-local" {
-    inline = ["virt-sysprep -a output-rhel8/packer-rhel-8-x86_64 --operations all,-lvm-uuids,-user-account,-firewall-rules,-fs-uuids,-flag-reconfiguration,-machine-id --scrub /etc/machine-id"]
+    inline = ["virt-sysprep -a output-rhel8/packer-rhel-8-x86_64 --operations defaults,-lvm-uuids --run-command '> /etc/machine-id'"]
   }
 }

--- a/packer/rhel9.pkr.hcl
+++ b/packer/rhel9.pkr.hcl
@@ -30,6 +30,6 @@ source "qemu" "rhel9" {
 build {
   sources = ["source.qemu.rhel9"]
   post-processor "shell-local" {
-    inline = ["virt-sysprep -a output-rhel9/packer-rhel-9-x86_64 --operations all,-lvm-uuids,-user-account,-firewall-rules,-fs-uuids,-flag-reconfiguration,-machine-id --scrub /etc/machine-id"]
+    inline = ["virt-sysprep -a output-rhel9/packer-rhel-9-x86_64 --operations defaults,-lvm-uuids --run-command '> /etc/machine-id'"]
   }
 }

--- a/terraform/templates/cloud_init_user_data.tftpl
+++ b/terraform/templates/cloud_init_user_data.tftpl
@@ -12,4 +12,3 @@ users:
 runcmd:
   - /usr/bin/growpart /dev/vda 2
   - pvresize /dev/vda2
-  - systemd-machine-id-setup


### PR DESCRIPTION
The rhel9 template was broken, since systemd on rhel9 can't deal with a missing /etc/system-id file during boot.