### PR TITLE
Fix docs typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To deploy the VMs using the built images, navigate to the `terraform` directory 
 ## Using Ansible to provision VMs
 
 The playbooks in the `ansible` directory can be used to provision the VMs deployed by terraform. You can use `ansible-playbook` command to run the playbooks.
-During the terraform deployment a `ansible.cfg` is created containing the user that is specified in the [variables.tf](terrafrom/variables.tf) file. The default user is `cloud-user`.
+During the terraform deployment an `ansible.cfg` is created containing the user that is specified in the [variables.tf](terraform/variables.tf) file. The default user is `cloud-user`.
 Also the `ansible/inventory/hosts` is updated with the new information via terraform.
 
 ## Troubleshooting

--- a/packer/README.md
+++ b/packer/README.md
@@ -11,7 +11,7 @@ steps:
 ### Download iso files
 
 Check the `rhel<version>.pkr.hcl` packer files for what iso files are needed.
-Download en put these in the iso-files directory.
+Download and put these in the iso-files directory.
 
 ## Build packer images
 
@@ -19,7 +19,7 @@ Download en put these in the iso-files directory.
 $ packer init .
 ```
 
-To build all versions in parralel.
+To build all versions in parallel.
 
 ``` shell
 $ packer build .

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -6,7 +6,7 @@ vms = {
     rhel_version = "9"
     group        = "ansible_group1"
   }
-  exmaple2 = {
+  example2 = {
     storage      = "20"
     memory       = "2048"
     cpu          = "1"


### PR DESCRIPTION
## Summary
- fix typos in packer docs
- fix variable typo in terraform vars example
- fix wording and link path in top level README

## Testing
- `grep -n "parallel" -n packer/README.md`
