### PR TITLE
Fix trailing spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ packer build .
 
 ## Configuring libvirt
 
-The libvirt configuration is based on the following instructions:  
-[howto-automated-dns-resolution-for-kvmlibvirt-guests-with-a-local-domain](https://liquidat.wordpress.com/2017/03/03/howto-automated-dns-resolution-for-kvmlibvirt-guests-with-a-local-domain/).  
+The libvirt configuration is based on the following instructions:
+[howto-automated-dns-resolution-for-kvmlibvirt-guests-with-a-local-domain](https://liquidat.wordpress.com/2017/03/03/howto-automated-dns-resolution-for-kvmlibvirt-guests-with-a-local-domain/).
 This configuration uses `home.arpa` for the domain name. (see [rfc8375](https://datatracker.ietf.org/doc/html/rfc8375)).
 
 ### Edit libvirt Local Domain

--- a/ansible/lnx_rhel_soe_configure_swap.yml
+++ b/ansible/lnx_rhel_soe_configure_swap.yml
@@ -15,7 +15,7 @@
       set_fact:
         swap_memory_size_gb: "{{ ( ansible_memtotal_mb * 2 ) / 1024 | round }}"
         change_swap: true
-      when: 
+      when:
         - ansible_memtotal_mb <= 2048
         - ansible_swaptotal_mb >= ( ansible_memtotal_mb * 2 )
 
@@ -24,19 +24,19 @@
       set_fact:
         swap_memory_size_gb: "4"
         change_swap: true
-      when: 
+      when:
         - ansible_memtotal_mb > 2048
         - ansible_memtotal_mb <= 8192
         - ansible_swaptotal_mb >= ansible_memtotal_mb
 
       # > 8 GB – 64 GB	At least 4 GB
-    - name: Memory bigger than 8GB 
+    - name: Memory bigger than 8GB
       set_fact:
         swap_memory_size_gb: "4"
         change_swap: true
-      when: 
+      when:
         - ansible_memtotal_mb > 8192
-        - ansible_swaptotal_mb <= 4094 
+        - ansible_swaptotal_mb <= 4094
 
     - name: Resize Swap
       block:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -11,7 +11,7 @@ Variables
 * Copy `terraform.tfvars.example` to `terraform.tfvars` (or another name that ends with .tfvars)
 * Fill out your `terraform.tfvars` file
 * Run `terraform init` to initialize the directory that contains a Terraform configuration
-* Run `terraform plan -var-file=terraform.tfvars` to evaluate a Terraform configuration to determine the desired state 
+* Run `terraform plan -var-file=terraform.tfvars` to evaluate a Terraform configuration to determine the desired state
 * Run `terraform apply -var-file=terraform.tfvars` to carry out the planned changes to each resource
 
 


### PR DESCRIPTION
## Summary
- remove trailing spaces across docs and Ansible playbook

## Testing
- `grep -nI '[[:blank:]]$' -r --exclude-dir=.git`
