### PR TITLE
Deduplicate Terraform instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,7 @@ sudo systemctl restart NetworkManager
 
 ## Using Terraform to deploy VMs
 
-To deploy the VMs using the built images, navigate to the `terraform` directory and follow these steps:
-
-### Variables
-
-1. Copy `terraform.tfvars.example` to `terraform.tfvars` (or another name that ends with .tfvars)
-2. Fill out your `terraform.tfvars` file
-3. Run `terraform init` to initialize the directory that contains a Terraform configuration
-4. Run `terraform plan -var-file=terraform.tfvars` to evaluate a Terraform configuration to determine the desired state
-5. Run `terraform apply -var-file=terraform.tfvars` to carry out the planned changes to each resource
-
-> **note**: you can auto load the tfvars file without the `-var-file=terraform.tfvars` by putting `auto` in the name. For example: `terraform.auto.tfvars`
+Navigate to the `terraform` directory to deploy the VMs. Detailed steps for configuring variables and running Terraform are documented in [terraform/README.md](terraform/README.md).
 
 ## Using Ansible to provision VMs
 

--- a/tasks.json
+++ b/tasks.json
@@ -11,7 +11,8 @@
     },
     {
       "id": "deduplicate-readme",
-      "description": "Deduplicate repeated Terraform instructions across README files"
+      "description": "Deduplicate repeated Terraform instructions across README files",
+      "done": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- reference the Terraform README from the main README
- mark `deduplicate-readme` task as complete

## Testing
- `ruff check .`
- `ansible-lint` *(fails: command not found)*
- `yamllint .` *(fails: command not found)*
- `terraform fmt -recursive` *(fails: command not found)*
- `packer fmt -recursive` *(fails: command not found)*