### PR TITLE
Add RHEL10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Additionally, after the provisioning process with Terraform, it will create an u
 
 ### Download ISO files
 
-To create the RHEL images, you'll need to download the appropriate ISO files and place them in the `packer/iso-files` directory. Check the `rhel8.pkr.hcl` and `rhel9.pkr.hcl` packer config files to see which ISO files are needed.
+To create the RHEL images, you'll need to download the appropriate ISO files and place them in the `packer/iso-files` directory. Check the `rhel.pkr.hcl` packer config file to see which ISO files are needed for each supported release.
 
 ## Building Packer Images
 

--- a/ansible/lnx_rhel8_tailscale.yml
+++ b/ansible/lnx_rhel8_tailscale.yml
@@ -6,15 +6,15 @@
     - name: Import gpg key
       ansible.builtin.rpm_key:
         state: present
-        key: https://pkgs.tailscale.com/stable/rhel/8/repo.gpg
+        key: https://pkgs.tailscale.com/stable/rhel/{{ ansible_distribution_major_version }}/repo.gpg
 
     - name: Add repository
       ansible.builtin.yum_repository:
         name: tailscale-stable
         description: "Tailscale stable"
         file: tailscale
-        baseurl: https://pkgs.tailscale.com/stable/rhel/8/$basearch
-        gpgkey: https://pkgs.tailscale.com/stable/rhel/8/repo.gpg
+        baseurl: https://pkgs.tailscale.com/stable/rhel/{{ ansible_distribution_major_version }}/$basearch
+        gpgkey: https://pkgs.tailscale.com/stable/rhel/{{ ansible_distribution_major_version }}/repo.gpg
         gpgcheck: false
         repo_gpgcheck: true
         enabled: true

--- a/ansible/lnx_rhel_soe_enable_epel.yml
+++ b/ansible/lnx_rhel_soe_enable_epel.yml
@@ -15,13 +15,13 @@
         - ansible_distribution == "RedHat"
         - ansible_distribution_major_version == "7"
 
-    - name: Enable required rhel8 or rhel9 repository
+    - name: Enable required rhel8, rhel9 or rhel10 repository
       community.general.rhsm_repository:
         name: "codeready-builder-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
         state: enabled
       when:
         - ansible_distribution == "RedHat"
-        - (ansible_distribution_major_version == "8") or (ansible_distribution_major_version == "9")
+        - (ansible_distribution_major_version == "8") or (ansible_distribution_major_version == "9") or (ansible_distribution_major_version == "10")
 
     - name: Install EPEL rpm
       ansible.builtin.yum:

--- a/packer/README.md
+++ b/packer/README.md
@@ -25,8 +25,8 @@ To build all versions in parallel.
 $ packer build .
 ```
 
-To build a specific version (e.g. RHEL 8).
+To build a specific version (e.g. RHEL 9 or RHEL 10).
 
 ``` shell
-$ packer build -only=qemu.rhel.8 .
+$ packer build -only=qemu.rhel.9 .
 ```

--- a/packer/config/ks-el10.cfg
+++ b/packer/config/ks-el10.cfg
@@ -1,0 +1,62 @@
+cdrom
+lang en_US.UTF-8
+keyboard us
+network  --bootproto=dhcp
+firewall --disabled
+selinux --permissive
+timezone UTC
+bootloader --location=mbr
+text
+repo --name="AppStream" --baseurl=file:///run/install/sources/mount-0000-cdrom/AppStream
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+authselect --enableshadow --passalgo=sha512 --kickstart
+firstboot --disabled
+eula --agreed
+services --enabled=NetworkManager,sshd,qemu-guest-agent
+user --name=cloud-user --plaintext --password=cloud-user --groups=wheel
+reboot
+
+%packages --ignoremissing --excludedocs
+@Core
+cloud-init
+cloud-utils-growpart
+openssh-clients
+qemu-guest-agent
+sudo
+
+# unnecessary firmware
+-iwl100-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl1000-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6050-firmware
+-iwl7260-firmware
+-libertas-usb8388-firmware
+
+#rhel10
+%end
+
+%post
+dnf update -y
+
+# sudo
+echo "cloud-user        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/90-cloud-init-users
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+mount /dev/sr1 /mnt
+cp -rf /mnt/cloud.cfg /etc/cloud/cloud.cfg
+
+dnf clean all
+%end

--- a/packer/rhel.pkr.hcl
+++ b/packer/rhel.pkr.hcl
@@ -20,6 +20,11 @@ variable "rhel_builds" {
       iso_checksum = "sha256:a387f3230acf87ee38707ee90d3c88f44d7bf579e6325492f562f0f1f9449e89"
       ks_file      = "config/ks-el9.cfg"
     }
+    "10" = {
+      iso_url      = "iso-files/rhel-baseos-10.0-x86_64-dvd.iso"
+      iso_checksum = "sha256:TODO"
+      ks_file      = "config/ks-el10.cfg"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add placeholder kickstart for RHEL10
- update packer build map with RHEL10 entry
- make tailscale role handle any major RHEL version
- enable EPEL repo for RHEL10 systems
- update README docs for unified packer config and new version support

## Testing
- `ruff check .`
- `ansible-lint ansible` *(fails: command not found)*
- `yamllint ansible` *(fails: command not found)*
- `terraform fmt -recursive` *(fails: command not found)*
- `packer fmt -check packer` *(fails: command not found)*
- `ksvalidator packer/config/ks-el7.cfg` *(fails: command not found)*